### PR TITLE
Instantiating Private CA module with initial commit of TF resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,50 @@
 # Terraform Google CAS
 
 Terraform code for managing Google's Certificate Authority Service and IAM permissions on those resources.
+
+## Example Usage
+
+```
+locals {
+  organization        = "Dapper Labs"
+  organizational_unit = "SRE"
+  lifetime            = "946100000s" # ~30 years
+  algorithm           = "EC_P256_SHA256"
+  common_name_prefix  = "sre-sandbox-ca"
+}
+
+module "private-ca" {
+  source = "github.com/dapperlabs-platform/terraform-google-cas?ref=instantiate-module"
+
+  region      = var.default_region
+  project_id  = var.project_name
+  environment = var.environment
+  root_config = {
+    organization        = local.organization
+    organizational_unit = local.organizational_unit
+    common_name         = "${local.common_name_prefix}-temporal-2023"
+    lifetime            = local.lifetime
+    algorithm           = local.algorithm
+  }
+
+  subordinate_config = {
+    organization        = local.organization
+    organizational_unit = local.organizational_unit
+    common_name         = "${local.common_name_prefix}-sub-temporal-2023"
+    lifetime            = local.lifetime
+    algorithm           = local.algorithm
+  }
+
+  deletion_protection                    = false
+  skip_grace_period                      = true
+  ignore_active_certificates_on_deletion = true
+}
+```
+
+### What this creates....
+
+- 2 Certificate Authority Pools, one for the root CA and one for the subordinate CAs. 
+- A root CA in the root CA pool
+- A subordinate CA in the subordinate CA pool
+- A service account
+- And IAM binding that grants the serice account `privateca.certificateRequester` on the subordinate CA pool

--- a/iam.tf
+++ b/iam.tf
@@ -1,0 +1,5 @@
+resource "google_privateca_ca_pool_iam_member" "certificate-requester-iam" {
+  ca_pool = google_privateca_ca_pool.temporal-subordinate-ca-pool.id
+  role    = "roles/privateca.certificateRequester"
+  member  = module.sa-google-cas-issuer.iam_email
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,156 @@
+# Used in the certificate_authority_id setting as you cannot reuse the ID in the event that the CA gets recreated
+# All variables in the keepers section would cause the CA resources to be recreated, thus if they are updated
+# the random_id will also be updated and thus prevent an error from occuring when recreating the CAs.
+resource "random_id" "rand" {
+  byte_length = 8
+
+  keepers = {
+    region                   = var.region
+    root_organization        = var.root_config.organization
+    root_organizational_unit = var.root_config.organizational_unit
+    root_common_name         = var.root_config.common_name
+    root_lifetime            = var.root_config.lifetime
+    root_algorithm           = var.root_config.algorithm
+    sub_organization         = var.subordinate_config.organization
+    sub_organizational_unit  = var.subordinate_config.organizational_unit
+    sub_common_name          = var.subordinate_config.common_name
+    sub_lifetime             = var.subordinate_config.lifetime
+    sub_algorithm            = var.subordinate_config.algorithm
+  }
+}
+
+resource "google_privateca_ca_pool" "temporal-subordinate-ca-pool" {
+  name     = "subordinate-ca-pool-${var.project_id}"
+  location = var.region
+  tier     = "ENTERPRISE"
+  project  = var.project_id
+  publishing_options {
+    publish_ca_cert = true
+    publish_crl     = true
+  }
+  labels = {
+    environment  = var.environment
+    project_name = var.project_id
+  }
+}
+
+resource "google_privateca_ca_pool" "temporal-root-ca-pool" {
+  name     = "root-ca-pool-${var.project_id}"
+  location = var.region
+  tier     = "ENTERPRISE"
+  project  = var.project_id
+  publishing_options {
+    publish_ca_cert = true
+    publish_crl     = true
+  }
+  labels = {
+    environment  = var.environment
+    project_name = var.project_id
+  }
+}
+
+resource "google_privateca_certificate_authority" "temporal-root-ca" {
+  certificate_authority_id = "root-ca-${var.project_id}-${random_id.rand.id}"
+  location                 = random_id.rand.keepers.region
+  pool                     = google_privateca_ca_pool.temporal-root-ca-pool.name
+  config {
+    subject_config {
+      subject {
+        organization        = random_id.rand.keepers.root_organization
+        organizational_unit = random_id.rand.keepers.root_organizational_unit
+        common_name         = random_id.rand.keepers.root_common_name
+      }
+    }
+    x509_config {
+      ca_options {
+        is_ca = true
+      }
+      key_usage {
+        base_key_usage {
+          cert_sign = true
+          crl_sign  = true
+        }
+        extended_key_usage {
+          server_auth = false
+        }
+      }
+    }
+  }
+  type     = "SELF_SIGNED"
+  lifetime = random_id.rand.keepers.root_lifetime
+  # "946100000s"
+  key_spec {
+    algorithm = random_id.rand.keepers.root_algorithm
+  }
+
+  // Disable CA deletion related safe checks for easier cleanup.
+  deletion_protection                    = var.deletion_protection
+  skip_grace_period                      = var.skip_grace_period
+  ignore_active_certificates_on_deletion = var.ignore_active_certificates_on_deletion
+
+  # We would want a new CA to come up before an old one is torn down to prevent any downtime
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "google_privateca_certificate_authority" "temporal-subordinate-ca" {
+  certificate_authority_id = "subordinate-ca-${var.project_id}-${random_id.rand.id}"
+  location                 = random_id.rand.keepers.region
+  pool                     = google_privateca_ca_pool.temporal-subordinate-ca-pool.name
+  subordinate_config {
+    certificate_authority = google_privateca_certificate_authority.temporal-root-ca.name
+  }
+  config {
+    subject_config {
+      subject {
+        organization        = random_id.rand.keepers.sub_organization
+        organizational_unit = random_id.rand.keepers.sub_organizational_unit
+        common_name         = random_id.rand.keepers.sub_common_name
+      }
+    }
+    x509_config {
+      ca_options {
+        is_ca = true
+        # Force the sub CA to only issue leaf certs
+        max_issuer_path_length = 0
+      }
+      key_usage {
+        base_key_usage {
+          digital_signature  = true
+          content_commitment = true
+          key_encipherment   = false
+          data_encipherment  = true
+          key_agreement      = true
+          cert_sign          = true
+          crl_sign           = true
+          decipher_only      = true
+        }
+        extended_key_usage {
+          server_auth      = true
+          client_auth      = false
+          email_protection = true
+          code_signing     = true
+          time_stamping    = true
+        }
+      }
+    }
+  }
+  type     = "SUBORDINATE"
+  lifetime = random_id.rand.keepers.sub_lifetime
+  key_spec {
+    algorithm = random_id.rand.keepers.sub_algorithm
+  }
+
+  // Disable CA deletion related safe checks for easier cleanup.
+  deletion_protection                    = var.deletion_protection
+  skip_grace_period                      = var.skip_grace_period
+  ignore_active_certificates_on_deletion = var.ignore_active_certificates_on_deletion
+
+  # We would want a new CA to come up before an old one is torn down to prevent any downtime
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,4 @@
+output "sa_email" {
+  description = "The email of the service account with the permissions to request certificates from the subordinate CA pool."
+  value       = module.sa-google-cas-issuer.email
+}

--- a/service-accounts.tf
+++ b/service-accounts.tf
@@ -1,0 +1,6 @@
+module "sa-google-cas-issuer" {
+  source     = "github.com/dapperlabs-platform/terraform-google-iam-service-account?ref=v1.1.10"
+  project_id = var.project_id
+  name       = "sa-google-cas-issuer"
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,56 @@
+variable "region" {
+  description = "The GCP region to deploy the resources"
+  type        = string
+  default     = "us-west1"
+}
+
+variable "project_id" {
+  description = "The ID of the GCP project to deploy the resources"
+  type        = string
+}
+
+variable "environment" {
+  description = "The environment to deploy into (e.g. staging, production, sandbox...)"
+  type        = string
+}
+
+variable "root_config" {
+  description = "Settings for the Root CA that is created by the module"
+  type = object({
+    organization        = string
+    organizational_unit = optional(string)
+    common_name         = string
+    lifetime            = string
+    algorithm           = string
+  })
+}
+
+
+variable "subordinate_config" {
+  description = "Settings for the Root CA that is created by the module"
+  type = object({
+    organization        = string
+    organizational_unit = optional(string)
+    common_name         = string
+    lifetime            = string
+    algorithm           = string
+  })
+}
+
+variable "deletion_protection" {
+  description = "If set to true, it will prevent Terraform from deleting the CAs"
+  type        = bool
+  default     = true
+}
+
+variable "skip_grace_period" {
+  description = "If set to true, CA will be deleted immediatedly, otherwise there will be a 30-day grace period."
+  type        = bool
+  default     = false
+}
+
+variable "ignore_active_certificates_on_deletion" {
+  description = "If set to true, allows the CA to be deleted even if it has active certificates."
+  type        = bool
+  default     = false
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.3.8"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+}


### PR DESCRIPTION
Initial commit to create the Private CA module. This module creates two CA pools, each with a CA (one root CA, the other a subordinate CA) as well as a GCP service account with `certificateRequester` access to the subordinate CA pool.

Tested as working [here](https://github.com/dapperlabs/sre-infrastructure/pull/200#issuecomment-1639054418)

How to use shown [here](https://github.com/dapperlabs/sre-infrastructure/blob/bb5cc3c8701056506e610b7693869b99e388c9d0/terraform/sre/sandbox/certificate-authority.tf)