### PR TITLE
Changing CA pool tier to Devops

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,7 @@ resource "random_id" "rand" {
 resource "google_privateca_ca_pool" "temporal-subordinate-ca-pool" {
   name     = "subordinate-ca-pool-${var.project_id}"
   location = var.region
-  tier     = "ENTERPRISE"
+  tier     = "DEVOPS"
   project  = var.project_id
   publishing_options {
     publish_ca_cert = true
@@ -37,7 +37,7 @@ resource "google_privateca_ca_pool" "temporal-subordinate-ca-pool" {
 resource "google_privateca_ca_pool" "temporal-root-ca-pool" {
   name     = "root-ca-pool-${var.project_id}"
   location = var.region
-  tier     = "ENTERPRISE"
+  tier     = "DEVOPS"
   project  = var.project_id
   publishing_options {
     publish_ca_cert = true


### PR DESCRIPTION
Changing pool tier to DEVOPS as this better suits our use case for Temporal cert rotation and will result in cost savings. 
- [Tiers compared](https://cloud.google.com/certificate-authority-service/docs/tiers#:~:text=DevOps%3A%20Focused%20on%20high%20volume,where%20lifecycle%20management%20is%20important.)
- [Price Breakdown](https://cloud.google.com/certificate-authority-service/pricing)