### PR TITLE
publish_crl must be false for devops tier

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,13 +20,13 @@ resource "random_id" "rand" {
 }
 
 resource "google_privateca_ca_pool" "temporal-subordinate-ca-pool" {
-  name     = "subordinate-ca-pool-${var.project_id}"
+  name     = "subordinate-ca-pool-${var.project_id}${var.pool_name_extension}"
   location = var.region
   tier     = "DEVOPS"
   project  = var.project_id
   publishing_options {
     publish_ca_cert = true
-    publish_crl     = true
+    publish_crl     = false
   }
   labels = {
     environment  = var.environment
@@ -35,13 +35,13 @@ resource "google_privateca_ca_pool" "temporal-subordinate-ca-pool" {
 }
 
 resource "google_privateca_ca_pool" "temporal-root-ca-pool" {
-  name     = "root-ca-pool-${var.project_id}"
+  name     = "root-ca-pool-${var.project_id}${var.pool_name_extension}"
   location = var.region
   tier     = "DEVOPS"
   project  = var.project_id
   publishing_options {
     publish_ca_cert = true
-    publish_crl     = true
+    publish_crl     = false
   }
   labels = {
     environment  = var.environment

--- a/variables.tf
+++ b/variables.tf
@@ -54,3 +54,9 @@ variable "ignore_active_certificates_on_deletion" {
   type        = bool
   default     = false
 }
+
+variable "pool_name_extension" {
+  description = "Since you cannot ever re-use pool names, this variable allows you to add a new identifier to the end of the pool names in the event you ever need to recreate your pools"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
- the publish_crl setting mush be set to false for devops tier pools (wish this was documented literally anywhere....)
- you cannot reuse pool names ever, so in the event that we need to recreate a pool, I have added the variable `pool_name_extension` to grant the ability to recreate the pools with a slightly different name